### PR TITLE
Add tests for php 5.5 and 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 php:
+  - "5.5"
+  - "5.5"
   - "5.4"
   - "5.3"
 install:


### PR DESCRIPTION
This patch lets test run against php 5.5 and 5.6.