### PR TITLE
build: Change mikey179/vfsStream to mikey179/vfsstream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "1.0.0",
 		"phpunit/phpunit": "^4.1.0",
-		"mikey179/vfsStream": "^1.0"
+		"mikey179/vfsstream": "^1.0"
 	},
 	"autoload": {
 		"files": [


### PR DESCRIPTION
> Deprecation warning: require-dev.mikey179/vfsStream is invalid, 
> it should not contain uppercase characters.
> Please use mikey179/vfsstream instead.
> Make sure you fix this as under Composer 2.0 this will error.